### PR TITLE
Fix tag in flask k6 test

### DIFF
--- a/k6/tests/python-flask.js
+++ b/k6/tests/python-flask.js
@@ -7,7 +7,7 @@ export const options = sharedOptions;
 
 export default function () {
   const res = http.get('http://python-flask:8000/hello-world', {
-    tags: { language: 'python', framework: 'fastapi', async: false, response: 'json', server: 'gunicorn'},
+    tags: { language: 'python', framework: 'flask', async: false, response: 'json', server: 'gunicorn'},
   });
 
   check(res, {


### PR DESCRIPTION
## Summary
- correct framework tag in Flask k6 script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686861d17ddc8330b17bcd11d9f2ef6c